### PR TITLE
improve: Module-meta information display

### DIFF
--- a/client/components/Settings.vue
+++ b/client/components/Settings.vue
@@ -126,8 +126,10 @@
                       scrapedModules[i].name
                     }}</v-list-item-title>
 
-                    <v-list-item-subtitle>
-                      {{ scrapedModules[i].description }}
+                    <v-list-item-subtitle
+                      v-html="scrapedModules[i].description"
+                      style="white-space: break-spaces"
+                    >
                     </v-list-item-subtitle>
                   </v-list-item-content>
 


### PR DESCRIPTION
Instead of using a string with elipsis, that is shown in the modules, the meta-informations is now fully shown and can also contain HTML. This is especially helpfull for linking directly to the module-configuration or for adding other information.