### PR TITLE
feat: Custom show-in settings

### DIFF
--- a/client/components/Modules.vue
+++ b/client/components/Modules.vue
@@ -52,9 +52,12 @@ export default {
     },
     scrapedModules() {
       return this.$store.state.scrapedModules.filter(
-        (m) =>
-          (m.shownIn.includes(this.modulesType) || m.shownIn == "*") &&
-          (this.role != "student" || !m.shownIn.includes("teacher-only"))
+        (m) => {
+          const showIn = m.showInCustom ? m.showInCustom.split(",").map((e) => e.trim()) : m.shownIn
+
+          return (showIn.includes(this.modulesType) || showIn == "*") &&
+            (this.role != "student" || !showIn.includes("teacher-only"))
+        }
       );
     },
   },

--- a/server/data.ts
+++ b/server/data.ts
@@ -153,6 +153,7 @@ export type Module = {
   studentConfig: string | Record<string, unknown>
   teacherConfig: string | Record<string, unknown>
   stationConfig: string | Record<string, unknown>
+  showInCustom: string
   width: 'full' | 'half' | 'third'
   height: 'tall' | 'medium' | 'short'
 }

--- a/server/env.ts
+++ b/server/env.ts
@@ -67,6 +67,7 @@ export const config_default_modules = JSON.parse(
     studentConfig: '',
     teacherConfig: '',
     stationConfig: '',
+    showInCustom: '',
     width: 'full',
     height: 'tall',
   },


### PR DESCRIPTION
The show-in meta information is now used as default, but the user can overwrite this within settings, allowing to open video-chat only within the station, add teacher-only, etc ...